### PR TITLE
feat: updating regex to account for 64 characters (CORE-5362)

### DIFF
--- a/src/constants/regexp.ts
+++ b/src/constants/regexp.ts
@@ -4,7 +4,7 @@ export const SLOT_REGEXP = /{{\[([^ .[\]{}]*?)]\.([^ .[\]{}]*?)}}/g;
 
 export const IS_VARIABLE_REGEXP = /^{.*}$/;
 
-export const READABLE_VARIABLE_REGEXP = /\{([a-zA-Z0-9_]{1,32})\}/g;
+export const READABLE_VARIABLE_REGEXP = /\{([a-zA-Z0-9_]{1,64})\}/g;
 
 export const VALID_CHARACTER = 'a-zA-Z';
 


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements CORE-5362**

### Brief description. What is this change?

Changing the regex for variable names to accommodate longer variable names up to 64 characters.

### Implementation details. How do you make this change?

Updated the regex.

### Setup information

None

### Deployment Notes

None

### Related PRs

| branch              | PR          |
| ------------------- | ----------- |
| `creator-app` | [link](https://github.com/voiceflow/creator-app/pull/3089) |

### Checklist

- [x] title of PR reflects the branch name
- [x] all commits adhere to conventional commits
- [x] appropriate tests have been written
- [x] all the dependendencies are upgraded