### PR TITLE
feat: support type param to `getOptionalProcessEnv` (VF-000)

### DIFF
--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -16,10 +16,10 @@ export const getRequiredProcessEnv = (name: string): string => {
 
 export function getOptionalProcessEnv(name: string, defaultVar?: never): null;
 
-export function getOptionalProcessEnv(name: string, defaultVar: string): string;
+export function getOptionalProcessEnv<T>(name: string, defaultVar: T): T | string;
 
 // eslint-disable-next-line prefer-arrow/prefer-arrow-functions
-export function getOptionalProcessEnv(name: string, defaultVar?: string): null | string {
+export function getOptionalProcessEnv<T>(name: string, defaultVar?: T): null | T | string {
   return hasProcessEnv(name) ? getRequiredProcessEnv(name) : defaultVar ?? null;
 }
 


### PR DESCRIPTION
**Fixes or implements VF-000**

### Brief description. What is this change?

You can do this now:

![wow cool types :))](https://user-images.githubusercontent.com/7608555/130033252-0c4d0ba0-a8c0-4a5c-bc93-bd693bb458fe.png)


Previously you needed something like this where the default value was a string:

![not very cool old types](https://user-images.githubusercontent.com/7608555/130032852-e8a7d4c8-1d63-49a3-a076-f2abb00b6e53.png)

### Implementation details. How do you make this change?

Adds a type param to better reflect the behavior of the function.

### Related PRs

Once merged: clean up all the ugly code that uses the older method.

### Checklist

- [x] title of PR reflects the branch name
- [x] all commits adhere to conventional commits
- [ ] appropriate tests have been written
- [ ] all the dependencies are upgraded
