### PR TITLE
feat: rewrite `process.env` functions (VF-000)

### DIFF
--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -15,7 +15,7 @@ export const getRequiredProcessEnv = (name: string): string => {
 };
 
 export function getOptionalProcessEnv<T>(name: string): null | string;
-export function getOptionalProcessEnv<T>(name: string, defaultVar: T): T | string;
+export function getOptionalProcessEnv<T>(name: string, defaultVar: T): (T extends NonNullable<T> ? T : NonNullable<T> | null) | string;
 
 // eslint-disable-next-line prefer-arrow/prefer-arrow-functions
 export function getOptionalProcessEnv<T>(name: string, defaultVar?: T | undefined): (null | T) | string {

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -2,24 +2,32 @@ import dotenv from 'dotenv';
 import fs from 'fs';
 import path from 'path';
 
-export const hasProcessEnv = (name: string): boolean => name in process.env;
+const normalizeEnvValue = (value: string) => value.trim();
+
+export const hasProcessEnv = (name: string): boolean => !!normalizeEnvValue(process.env[name] ?? '');
 
 export const getRequiredProcessEnv = (name: string): string => {
-  const envVar = process.env[name]?.trim();
-
-  if (!envVar) {
-    throw new Error(`env var: ${name} not found`);
+  if (hasProcessEnv(name)) {
+    return normalizeEnvValue(process.env[name]!);
   }
 
-  return envVar;
+  throw new Error(`env var: ${name} not found`);
 };
 
-export function getOptionalProcessEnv<T>(name: string): null | string;
-export function getOptionalProcessEnv<T>(name: string, defaultVar: T): (T extends NonNullable<T> ? T : NonNullable<T> | null) | string;
+// null or undefined will return the variable or null
+export function getOptionalProcessEnv(name: string, defaultVar?: null | undefined): string | null;
+// will return the variable or string of default value
+export function getOptionalProcessEnv(name: string, defaultVar: unknown): string;
+export function getOptionalProcessEnv(name: string, defaultVar?: unknown): string | null {
+  if (hasProcessEnv(name)) {
+    return getRequiredProcessEnv(name);
+  }
 
-// eslint-disable-next-line prefer-arrow/prefer-arrow-functions
-export function getOptionalProcessEnv<T>(name: string, defaultVar?: T | undefined): (null | T) | string {
-  return hasProcessEnv(name) ? getRequiredProcessEnv(name) : defaultVar ?? null;
+  if (defaultVar === null || defaultVar === undefined) {
+    return null;
+  }
+
+  return typeof defaultVar === 'object' ? JSON.stringify(defaultVar!) : String(defaultVar);
 }
 
 /* eslint-disable no-console */

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -14,12 +14,11 @@ export const getRequiredProcessEnv = (name: string): string => {
   return envVar;
 };
 
-export function getOptionalProcessEnv(name: string, defaultVar?: never): null;
-
+export function getOptionalProcessEnv<T>(name: string): null | string;
 export function getOptionalProcessEnv<T>(name: string, defaultVar: T): T | string;
 
 // eslint-disable-next-line prefer-arrow/prefer-arrow-functions
-export function getOptionalProcessEnv<T>(name: string, defaultVar?: T): null | T | string {
+export function getOptionalProcessEnv<T>(name: string, defaultVar?: T | undefined): (null | T) | string {
   return hasProcessEnv(name) ? getRequiredProcessEnv(name) : defaultVar ?? null;
 }
 

--- a/tests/utils.unit.ts
+++ b/tests/utils.unit.ts
@@ -1,11 +1,53 @@
 import { expect } from 'chai';
 
-import { getRequiredProcessEnv } from '@/utils/env';
+import { getOptionalProcessEnv, getRequiredProcessEnv } from '@/utils/env';
 
-describe('test utils functions', () => {
+const TEST_ENV_VAR = 'TEST_ENV_VAR';
+
+describe('getRequiredProcessEnv', () => {
+  beforeEach(() => {
+    delete process.env[TEST_ENV_VAR];
+  });
+
   it('throws if process env is not found', () => {
-    expect(() => getRequiredProcessEnv('FOO')).to.throw('env var: FOO not found');
-    process.env.FOO = 'something';
-    expect(getRequiredProcessEnv('FOO')).to.eql('something');
+    expect(() => getRequiredProcessEnv(TEST_ENV_VAR)).to.throw(`env var: ${TEST_ENV_VAR} not found`);
+    process.env[TEST_ENV_VAR] = 'something';
+    expect(getRequiredProcessEnv(TEST_ENV_VAR)).to.eql('something');
+  });
+
+  it('handles empty string values', () => {
+    expect(() => getRequiredProcessEnv(TEST_ENV_VAR)).to.throw(`env var: ${TEST_ENV_VAR} not found`);
+    process.env[TEST_ENV_VAR] = '   '; // whitespace
+    expect(() => getRequiredProcessEnv(TEST_ENV_VAR)).to.throw(`env var: ${TEST_ENV_VAR} not found`);
+  });
+});
+
+describe('getOptionalProcessEnv', () => {
+  beforeEach(() => {
+    delete process.env[TEST_ENV_VAR];
+  });
+
+  it('works with no default value', () => {
+    expect(getOptionalProcessEnv(TEST_ENV_VAR)).to.eql(null);
+    expect(getOptionalProcessEnv(TEST_ENV_VAR, undefined)).to.eql(null);
+  });
+
+  it('works with a default value', () => {
+    expect(getOptionalProcessEnv(TEST_ENV_VAR, null)).to.eql(null);
+    expect(getOptionalProcessEnv(TEST_ENV_VAR, 123)).to.eql('123');
+    expect(getOptionalProcessEnv(TEST_ENV_VAR, { a: 1, b: 2 })).to.eql(JSON.stringify({ a: 1, b: 2 }));
+
+    // falsy values
+    expect(getOptionalProcessEnv(TEST_ENV_VAR, 0)).to.eql('0');
+    expect(getOptionalProcessEnv(TEST_ENV_VAR, false)).to.eql('false');
+    expect(getOptionalProcessEnv(TEST_ENV_VAR, '')).to.eql('');
+  });
+
+  it('gets the environment variable', () => {
+    process.env[TEST_ENV_VAR] = '   '; // whitespace
+    expect(getOptionalProcessEnv(TEST_ENV_VAR)).to.eql(null);
+
+    process.env[TEST_ENV_VAR] = 'hello';
+    expect(getOptionalProcessEnv(TEST_ENV_VAR)).to.eql('hello');
   });
 });


### PR DESCRIPTION
**Fixes or implements VF-000**

### Brief description. What is this change?

I didn't fully test #51 and accidentally screwed up the return types (`getOptionalProcessEnv('x')` is typed as always returning `string` instead of `string | null`).

I'm a bit confused how typescript let me do this, probably something to do with overloads being quirky.

### Related PRs

- #51

### Checklist

- [x] title of PR reflects the branch name
- [x] all commits adhere to conventional commits
- [ ] appropriate tests have been written
- [ ] all the dependencies are upgraded
