### PR TITLE
feat: add `EmptyObject` type (VF-000)

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -30,3 +30,9 @@ export type NullableRecord<T extends object> = { [K in keyof T]: Nullable<T[K]> 
 export type NonNullishRecord<T extends object> = Required<{ [K in keyof T]: Exclude<T[K], null> }>;
 
 export type Struct = Record<string, unknown>;
+
+/**
+ * An object with no keys or values.
+ * @see https://github.com/typescript-eslint/typescript-eslint/issues/2063#issuecomment-675156492
+ */
+export type EmptyObject = Record<never, never>;


### PR DESCRIPTION
**Fixes or implements VF-000**

### Brief description. What is this change?

Adds a type for an empty object.

### Checklist

- [x] title of PR reflects the branch name
- [x] all commits adhere to conventional commits
- [ ] this is a breaking change and should publish a new major version
- [ ] appropriate tests have been written
- [ ] all the dependencies are upgraded
