### PR TITLE
feat: add `Environment` enum for `process.env.NODE_ENV` (VF-000)

### DIFF
--- a/src/constants/environment.ts
+++ b/src/constants/environment.ts
@@ -1,0 +1,8 @@
+/* eslint-disable import/prefer-default-export */
+
+export enum Environment {
+  PRODUCTION = 'production',
+  LOCAL = 'local',
+  E2E = 'e2e',
+  TEST = 'test',
+}

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,3 +1,4 @@
+export * from './environment';
 export * from './intent';
 export * from './regexp';
 export * from './slot';


### PR DESCRIPTION
**Fixes or implements VF-000**

### Brief description. What is this change?

```ts
import { Environment } from '@voiceflow/common';

if (process.env.NODE_ENV === Environment.PRODUCTION) {
	// ...
}
```

### Related PRs

- voiceflow/backend-utils#45

### Checklist

- [ ] this is a breaking change and should publish a new major version
- [ ] appropriate tests have been written
