### PR TITLE
fix: improve nullish types & utils (VF-000)

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/ban-types, @typescript-eslint/no-explicit-any */
 export type Nullable<T> = T | null;
-export type Nullish<T> = Nullable<T> | undefined;
+export type Nullish<T = unknown> = Nullable<T> | undefined;
 
 export type Function<A extends any[] = any[], R = any> = (...args: A) => R;
 
@@ -27,7 +27,7 @@ export type Writeable<T> = { -readonly [P in keyof T]: T[P] };
 
 export type NullableRecord<T extends object> = { [K in keyof T]: Nullable<T[K]> };
 
-export type NonNullishRecord<T extends object> = Required<{ [K in keyof T]: Exclude<T[K], null> }>;
+export type NonNullishRecord<T extends object> = Required<{ [K in keyof T]: NonNullable<T[K]> }>;
 
 export type Struct = Record<string, unknown>;
 

--- a/src/utils/array.ts
+++ b/src/utils/array.ts
@@ -108,4 +108,9 @@ export const asyncForEach = async <T>(array: T[], callback: (item: T, index: num
   }
 };
 
-export const filterOutNullish = <T>(items: Nullish<T>[]): T[] => items.filter((item = null) => item !== null) as T[];
+export const isNullish = (value: unknown): value is Nullish => value === null || value === undefined;
+
+export const isNotNullish = <T>(value: T): value is NonNullable<T> => value !== null && value !== undefined;
+
+/** @deprecated Use `array.filter(isNotNullish)` instead. */
+export const filterOutNullish = <T>(items: readonly T[]): Array<NonNullable<T>> => items.filter(isNotNullish);

--- a/tests/utils/array.unit.ts
+++ b/tests/utils/array.unit.ts
@@ -1,6 +1,21 @@
 import { expect } from 'chai';
 
-import { append, head, insert, insertAll, replace, tail, toggleMembership, unique, without, withoutValue, withoutValues } from '@/utils/array';
+import {
+  append,
+  filterOutNullish,
+  head,
+  insert,
+  insertAll,
+  isNotNullish,
+  isNullish,
+  replace,
+  tail,
+  toggleMembership,
+  unique,
+  without,
+  withoutValue,
+  withoutValues,
+} from '@/utils/array';
 
 describe('Utils | array', () => {
   describe('unique()', () => {
@@ -92,6 +107,30 @@ describe('Utils | array', () => {
       expect(tail(['a', 'b', 'c', 'd'])).to.eql([['a', 'b', 'c'], 'd']);
       expect(tail(['a'])).to.eql([[], 'a']);
       expect(tail([])).to.eql([[], undefined]);
+    });
+  });
+
+  describe('filterOutNullish()', () => {
+    it('filters nullish values', () => {
+      expect(filterOutNullish([undefined, 1, null])).to.eql([1]);
+      expect(filterOutNullish([undefined, null])).to.eql([]);
+      expect(filterOutNullish([1])).to.eql([1]);
+    });
+  });
+
+  describe('isNullish()', () => {
+    it('works', () => {
+      expect(isNullish(null)).to.eql(true);
+      expect(isNullish(undefined)).to.eql(true);
+      expect(isNullish(0)).to.eql(false);
+    });
+  });
+
+  describe('isNotNullish()', () => {
+    it('works', () => {
+      expect(isNotNullish(null)).to.eql(false);
+      expect(isNotNullish(undefined)).to.eql(false);
+      expect(isNotNullish(0)).to.eql(true);
     });
   });
 });


### PR DESCRIPTION
**Fixes or implements VF-000**

### Brief description. What is this change?

- you can do this now:
  ```ts
   type Whatever = Nullish;
   ```
- add `isNullish` and `isNotNullish` type guards
- deprecate `filterOutNullish(array)` in favor of `array.filter(isNotNullish)` (also, remove type assertion for max safety)
- add tests for all 3 functions
- `NonNullishRecord<T>` now excludes `null | undefined` instead of just `null`

### Checklist

- [ ] this is a breaking change and should publish a new major version
- [x] appropriate tests have been written