### PR TITLE
fix: deprecate `Environment.STAGING` (VF-000)

### DIFF
--- a/src/constants/environment.ts
+++ b/src/constants/environment.ts
@@ -6,5 +6,6 @@ export enum Environment {
   LOCAL = 'local',
   E2E = 'e2e',
   TEST = 'test',
+  /** @deprecated Voiceflow dev envs now use {@link Environment.DEVELOPMENT}  */
   STAGING = 'staging',
 }


### PR DESCRIPTION
**Fixes or implements VF-000**

### Brief description. What is this change?

all envs now use "development" instead of "staging"

### Checklist

- [ ] this is a breaking change and should publish a new major version
- [ ] appropriate tests have been written