### PR TITLE
feat: move protocol utilities to common package (VF-1989)

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "cuid": "^2.1.8",
     "dayjs": "^1.10.7",
     "lodash": "^4.17.21",
-    "number-to-words": "^1.2.4"
+    "number-to-words": "^1.2.4",
+    "typescript-fsa": "3.0.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^12.1.4",

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -9,6 +9,7 @@ export * as normalized from './normalized';
 export * as number from './number';
 export * as object from './object';
 export * as promise from './promise';
+export * as protocol from './protocol';
 export * as string from './string';
 export * as time from './time';
 export * as timezones from './timezones';

--- a/src/utils/protocol.ts
+++ b/src/utils/protocol.ts
@@ -1,0 +1,24 @@
+import actionCreatorFactory from 'typescript-fsa';
+
+export const createAction = actionCreatorFactory();
+
+export const typeFactory =
+  (...parts: string[]) =>
+  (name: string): string =>
+    [...parts, name].join('.');
+
+export class Channel<K extends string> {
+  constructor(public variables: K[], public build: (params: Record<K, string>) => string) {}
+
+  buildMatcher() {
+    return this.build(this.variables.reduce((acc, key) => Object.assign(acc, { [key]: `:${key}` }), {} as Record<K, string>));
+  }
+
+  extend<L extends string>(variables: L[], build: (params: Record<L, string>) => string) {
+    return new Channel<K | L>([...this.variables, ...variables], (params) => `${this.build(params)}/${build(params)}`);
+  }
+}
+
+export type ChannelParams<T extends Channel<string>> = T extends Channel<infer R> ? Record<R, string> : never;
+
+export const createChannel = <K extends string>(variables: K[], build: (params: Record<K, string>) => string) => new Channel(variables, build);

--- a/tests/utils/protocol.unit.ts
+++ b/tests/utils/protocol.unit.ts
@@ -1,0 +1,49 @@
+import { expect } from 'chai';
+
+import { Channel, createChannel, typeFactory } from '@/utils/protocol';
+
+describe('Utils | protocol', () => {
+  describe('typeFactory()', () => {
+    it('should generate a prefixed type', () => {
+      expect(typeFactory('red', 'blue')('green')).to.eq('red.blue.green');
+    });
+  });
+
+  describe('Channel', () => {
+    describe('build()', () => {
+      it('store original build function directly', () => {
+        const channel = new Channel(['foo', 'bar'], ({ foo, bar }) => `${foo}/fizz/buzz/${bar}`);
+
+        expect(channel.build({ foo: '123', bar: '456' })).to.eq('123/fizz/buzz/456');
+      });
+    });
+
+    describe('buildMatcher()', () => {
+      it('store build a matcher using the provided argument names', () => {
+        const channel = new Channel(['foo', 'bar'], ({ foo, bar }) => `${foo}/fizz/buzz/${bar}`);
+
+        expect(channel.buildMatcher()).to.eq(':foo/fizz/buzz/:bar');
+      });
+    });
+
+    describe('extend()', () => {
+      it('create a channel built to be suffixed to the output of an existing channel', () => {
+        const fooChannel = new Channel(['foo'], ({ foo }) => `foo/${foo}`);
+        const barChannel = fooChannel.extend(['bar'], ({ bar }) => `bar/${bar}`);
+
+        expect(barChannel.buildMatcher()).to.eq('foo/:foo/bar/:bar');
+        expect(barChannel.build({ foo: '123', bar: '456' })).to.eq('foo/123/bar/456');
+      });
+    });
+
+    describe('createChannel()', () => {
+      it('constructs a new Channel', () => {
+        const channel = createChannel(['foo'], ({ foo }) => `foo/${foo}`);
+
+        expect(channel).to.be.an.instanceOf(Channel);
+        expect(channel.buildMatcher()).to.eq('foo/:foo');
+        expect(channel.build({ foo: '123' })).to.eq('foo/123');
+      });
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -5560,6 +5560,11 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
+typescript-fsa@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/typescript-fsa/-/typescript-fsa-3.0.0.tgz#3ad1cb915a67338e013fc21f67c9b3e0e110c912"
+  integrity sha512-xiXAib35i0QHl/+wMobzPibjAH5TJLDj+qGq5jwVLG9qR4FUswZURBw2qihBm0m06tHoyb3FzpnJs1GRhRwVag==
+
 typescript@^4.2.4:
   version "4.2.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.4.tgz#8610b59747de028fda898a8aef0e103f156d0961"


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements VF-1989**

### Brief description. What is this change?

Adds simple utilities for creating types, channels and actions

### Checklist

- [ ] this is a breaking change and should publish a new major version
- [ ] appropriate tests have been written
